### PR TITLE
flashsim: add dummy imlementation of command 0x31

### DIFF
--- a/cpp/flashsim.cpp
+++ b/cpp/flashsim.cpp
@@ -403,6 +403,7 @@ int	FLASHSIM::operator()(const int csn, const int sck, const int dat) {
 			m_state = QSPIF_QUAD_READ_CMD;
 			m_mode = FM_QSPI;
 			break;
+		case 0x31:
 		case 0x000:
 		case 0x0ff:
 			m_state = QSPIF_IDLE;


### PR DESCRIPTION
PicoSoC on icebreaker uses command 0x31. Adding this dummy implementation allows booting default PicoSoC's FW